### PR TITLE
Bump node version to 16.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV LANG=C.UTF-8 LC_ALL=C.UTF-8 NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 # Node ppa provided by: https://github.com/nodesource/distributions
 RUN apt-get update && \
     apt-get install curl --yes && \
-    curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
+    curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
     apt-get update && \
     apt-get install --yes \
         build-essential ruby-dev ruby-bundler python3-dev python3-pip \


### PR DESCRIPTION
## Done
Bumped the node version from 12.x to 16.x

## QA
- Pull this branch down
- Run `docker build . --tag canonicalwebteam/dev:1.7.0`
- Check that builds correctly
- Navigate to a local project, such as global-nav or a website
- Open the `run` script
- Change the `dev_image` line to `dev_image="canonicalwebteam/dev:1.7.0"`
- Run `./run clean` then `./run`
- Check the project runs as expected

Fixes https://github.com/canonical-web-and-design/docker-dev/issues/18